### PR TITLE
Bumping the NUnit version to 3.11 and adding NonTestAssembly attribute

### DIFF
--- a/src/NUnitExtras.HierarchicalCategories.Tests/NUnitExtras.HierarchicalCategories.Tests.csproj
+++ b/src/NUnitExtras.HierarchicalCategories.Tests/NUnitExtras.HierarchicalCategories.Tests.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="NUnit" Version="3.7.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="7.8.0.7320">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NUnitExtras.HierarchicalCategories/AssemblyInfo.Custom.cs
+++ b/src/NUnitExtras.HierarchicalCategories/AssemblyInfo.Custom.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly:NonTestAssembly]

--- a/src/NUnitExtras.HierarchicalCategories/NUnitExtras.HierarchicalCategories.csproj
+++ b/src/NUnitExtras.HierarchicalCategories/NUnitExtras.HierarchicalCategories.csproj
@@ -31,7 +31,7 @@ NUnitExtras.HierarchicalCategories on GitHub: https://github.com/YevgeniyShunevy
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="3.7.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="7.8.0.7320">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
I have a project that is referencing this package as a dependency. My project was just updated to NUnit 3.11 and when running the nunit3-console, it incorrectly tries to run tests for this package instead of skipping it as a dependency. This change updates this package to NUnit 3.11 and adds the NonTestAssembly attribute to the assembly so that it can correctly be skipped when running the nunit3-console.